### PR TITLE
fix: Don't include image name on readAppTile

### DIFF
--- a/marketplace/resource_applet.go
+++ b/marketplace/resource_applet.go
@@ -37,10 +37,8 @@ func readAppTile(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		d.Set("image_hash", hash)
-		d.Set("image", app.Image.FileName+"."+app.Image.FileExtension)
 	} else {
 		d.Set("image_hash", nil)
-		d.Set("image", nil)
 	}
 
 	d.Set("name", app.Name)


### PR DESCRIPTION
As long as the hash is stable we don't actually care about the name
of the image file. It is also impossible to reliably reconstruct
the name because it might be some relative path that isn't stored
in the server.