### PR TITLE
feat: support auto_version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,18 @@ resource "app_tile" "example" {
   app_tile_id    = "some_id" # Probably get this from a applet resource from appstore
   image          = "icon.png"
   image_hash     = filemd5("./icon.png")
+  version        = "0.0.12"
+}
+
+resource "app_tile" "auto_version_example" {
+  provider       = marketplace
+  name           = "Example App Tile for Marketplace"
+  description    = "This applet is created and managed using terraform"
+  author_display = "LifeOmic"
+  app_tile_id    = "some_id" # Probably get this from a applet resource from appstore
+  image          = "icon.png"
+  image_hash     = filemd5("./icon.png")
+  auto_version   = true
 }
 ```
 
@@ -28,3 +40,6 @@ resource "app_tile" "example" {
 * app_tile_id: string
 * image: string # Path to image
 * image_hash: string # Hash so that we know when the image has changed
+* version: string
+* auto_version: bool # Will autoincrement the patch value on any change
+

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/smithy-go v1.9.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.tf
+++ b/main.tf
@@ -30,5 +30,11 @@ resource "app_tile" "anxiety" {
   image          = "icon-240.png"
   image_hash     = filemd5("./icon-240.png")
   app_tile_id    = var.app_tile_id
-  version        = "0.0.13"
+  auto_version   = true
+  lifecycle {
+    ignore_changes = [
+      image,
+      version,
+    ]
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Anxiety Severity Assessment Updated With Image",
+  "name": "Anxiety Severity Assessment Updated Auto Patch2",
   "description": "***What is this?***\n\nAn anxiety severity assessment based on the 7-item variant of the Generalized Anxiety Disorder (GAD-7) survey.\n\nGAD-7 is one of the most [frequently used](https://www.ncbi.nlm.nih.gov/pubmed/18388841) self-report based assessments for screening and preliminary diagnosis of anxiety disorders.\n\n***Who should use this?***\n\nAnyone seeking to better understand their relative anxiety severity.\n\nThis assessment does not provide medical advice. It is not intended for the purpose of any medical diagnosis or treatment. The informational content is intended for awareness and wellness education. Always seek the advice of your health care provider regarding questions about a medical condition.",
-  "app_tile_id": "d803c4d5-b9c8-4ecf-a214-798bd363f672"
+  "app_tile_id": "58e9ede8-eb28-40b6-82a6-d8b670d9c651"
 }

--- a/marketplace/client.go
+++ b/marketplace/client.go
@@ -130,9 +130,9 @@ func (client *MarketplaceClient) gql(query string, variables map[string]interfac
 }
 
 type appTileModule struct {
-	Name        string  `json:"title"`
-	Description string  `json:"description"`
-	Version     *string `json:"version"`
+	Name        string `json:"title"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
 	Source      struct {
 		Id string `json:"id"`
 	} `json:"source"`


### PR DESCRIPTION
In some cases the owner of a module might not care about the version.
The version still has to be incremented or marketplace-service
won't publish a new version, so this will auto increment the patch
value so that we get a new version each time.