### PR TITLE
fix: Remove the shared aws config

### DIFF
--- a/marketplace/client.go
+++ b/marketplace/client.go
@@ -395,7 +395,7 @@ func (client *MarketplaceClient) publishNewAppTileModule(params appTileCreate) (
 }
 
 func BuildAppStoreClient() (*MarketplaceClient, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithSharedConfigProfile("lifeomic-dev"))
+	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that the okta aws tool has been fixed we don't need to specify a profile anymore.
This makes running in different environments simpler.