### PR TITLE
fix: Fix publishV2 and handle retries for eventual consistency

### DIFF
--- a/marketplace/client.go
+++ b/marketplace/client.go
@@ -155,7 +155,7 @@ func (client *MarketplaceClient) getAppTileModule(id string) (*appTileModule, er
 	}
 	var body struct {
 		Data struct {
-			MyModule appTileModule `json:"myModule"`
+			MyModule *appTileModule `json:"myModule"`
 		} `json:"data"`
 	}
 	err = json.Unmarshal([]byte(payload.Body), &body)
@@ -163,7 +163,7 @@ func (client *MarketplaceClient) getAppTileModule(id string) (*appTileModule, er
 		return nil, err
 	}
 	module := body.Data.MyModule
-	return &module, nil
+	return module, nil
 }
 
 type appTileCreate struct {
@@ -384,7 +384,7 @@ func (client *MarketplaceClient) publishNewAppTileModule(params appTileCreate) (
 				Version struct {
 					Version string `json:"version"`
 				} `json:"version"`
-			} `json:"publishDraftModule"`
+			} `json:"publishDraftModuleV2"`
 		} `json:"data"`
 	}
 	err = json.Unmarshal([]byte(publishPayload.Body), &publishModuleBody)


### PR DESCRIPTION
After updating to the new publish mutation, creation changes stopped working.
Also there is a small chance of eventual consistency when creating a new module,
this should account for that and handle it gracefully.

https://support.hashicorp.com/hc/en-us/articles/1500006254562-Provider-Produced-Inconsistent-Results

> When a resource is created or updated on the remote backend, there are chances for a temporary condition to occur where the remote system is not operating fast enough to persist the information of the newly created resource or the updated resource into the storage for the subsequent read operation to retrieve the information of the resource accurately, however, the information will be eventually consistent. There are resources that have been implemented with extra logic to retry with the read operation, unfortunately, not all the available resources are implemented with the retry logic therefore the error message below may display at the end of the output of the failed run.