### PR TITLE
PW-712 add wellness offering resource schema

### DIFF
--- a/marketplace/provider.go
+++ b/marketplace/provider.go
@@ -14,7 +14,8 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 		Schema:        map[string]*schema.Schema{},
 		ResourcesMap: map[string]*schema.Resource{
-			"app_tile": appTileResource(),
+			"app_tile":          appTileResource(),
+			"wellness_offering": wellnessOfferingResource(),
 		},
 	}
 }

--- a/marketplace/resource_wellness_offering.go
+++ b/marketplace/resource_wellness_offering.go
@@ -48,11 +48,11 @@ func wellnessOfferingResource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"imageUrl": {
+			"image_url": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"infoUrl": {
+			"info_url": {
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/marketplace/resource_wellness_offering.go
+++ b/marketplace/resource_wellness_offering.go
@@ -1,0 +1,84 @@
+package marketplace
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var errNotImplemented = errors.New("resource handler not implemented yet")
+
+func createWellnessOffering(d *schema.ResourceData, meta interface{}) error {
+	return errNotImplemented
+}
+
+func readWellnessOffering(d *schema.ResourceData, meta interface{}) error {
+	return errNotImplemented
+
+}
+
+func updateWellnessOffering(d *schema.ResourceData, meta interface{}) error {
+	return errNotImplemented
+}
+
+func deleteWellnessOffering(d *schema.ResourceData, meta interface{}) error {
+	return errNotImplemented
+}
+
+func wellnessOfferingResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"marketplace_provider": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"auto_version": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"imageUrl": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"infoUrl": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"approximate_unit_cost_pennies": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"install_url": {
+				Required: true,
+			},
+			"configuration_schema": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"is_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+		Create: createWellnessOffering,
+		Read:   readWellnessOffering,
+		Update: updateWellnessOffering,
+		Delete: deleteWellnessOffering,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}


### PR DESCRIPTION
Setup the schema for `wellness_offering` resource with stubbed methods. Schema is based on https://github.com/lifeomic/ulta-service/blob/19747ad51702e67e9b727184360e9b4a6b360b0e/deploy/createWellnessSubsidyHook.js#L62