### PR TITLE
fix: Use Node 18 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v2.4.0
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
       - name: Install semantic-release Dependency
         run: npm install -g semantic-release conventional-changelog-conventionalcommits
       - name: Tag Release


### PR DESCRIPTION
>  [semantic-release]: node version >=18 is required. Found v16.18.1.